### PR TITLE
Mobile layout fixes: viewport overflow, nav wrapping, gutters

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,7 +33,7 @@
       }
 
       *{box-sizing:border-box;}
-      html{scroll-behavior:smooth;}
+      html{scroll-behavior:smooth; overflow-x:clip;}
       @media (prefers-reduced-motion: reduce){ html{scroll-behavior:auto;} }
       body{
         margin:0; background:var(--paper); color:var(--ink);
@@ -47,28 +47,38 @@
         color:var(--bronze); font-weight:600; margin:0 0 14px;
       }
       a{color:inherit;}
-      .wrap{max-width:1120px; margin:0 auto; padding:0 clamp(20px,5vw,56px);}
+      .wrap{max-width:1120px; margin:0 auto; padding-left:clamp(24px,5vw,56px); padding-right:clamp(24px,5vw,56px);}
 
       /* ---------- nav ---------- */
       nav{
-        display:flex; align-items:baseline; justify-content:space-between; gap:20px;
+        display:flex; flex-wrap:wrap; align-items:baseline; justify-content:space-between; gap:10px 20px;
         padding:26px clamp(20px,5vw,56px); border-bottom:1px solid var(--hairline);
         position:sticky; top:0; background:rgba(251,249,245,.92);
         backdrop-filter:blur(8px); z-index:50;
       }
-      .wordmark{font-size:.82rem; letter-spacing:.34em; text-transform:uppercase; font-weight:700; text-decoration:none;}
-      nav ul{display:flex; gap:30px; margin:0; padding:0; list-style:none;}
+      .wordmark{font-size:.82rem; letter-spacing:.34em; text-transform:uppercase; font-weight:700; text-decoration:none; white-space:nowrap;}
+      nav ul{display:flex; flex-wrap:wrap; gap:12px 30px; margin:0; padding:0; list-style:none; justify-content:flex-end;}
       nav ul a{
         font-size:.72rem; letter-spacing:.2em; text-transform:uppercase; text-decoration:none; color:var(--stone);
         padding-bottom:3px; border-bottom:1px solid transparent; transition:color .25s, border-color .25s;
+        white-space:nowrap;
       }
       nav ul a:hover{color:var(--bronze); border-color:var(--bronze);}
-      @media (max-width:640px){ nav ul{gap:16px;} nav ul li:nth-child(2){display:none;} }
+      @media (max-width:640px){
+        nav{padding:16px 24px;}
+        .wordmark{font-size:.72rem; letter-spacing:.22em;}
+        nav ul{gap:10px 16px;}
+        nav ul a{font-size:.62rem; letter-spacing:.12em;}
+      }
 
       /* ---------- hero ---------- */
-      .hero{padding:clamp(60px,10vh,120px) 0 clamp(50px,8vh,90px);}
+      .hero{padding-top:clamp(60px,10vh,120px); padding-bottom:clamp(50px,8vh,90px);}
       .hero-grid{display:grid; grid-template-columns:minmax(0,1.35fr) minmax(230px,.65fr); gap:clamp(30px,6vw,80px); align-items:end;}
-      @media (max-width:760px){ .hero-grid{grid-template-columns:1fr;} .hero-photo{order:-1; max-width:250px;} }
+      @media (max-width:760px){
+        .hero{padding-top:34px; padding-bottom:48px;}
+        .hero-grid{grid-template-columns:minmax(0,1fr); gap:26px;}
+        .hero-photo{order:-1; max-width:230px;}
+      }
       h1{
         font-size:clamp(2.6rem,6.4vw,4.9rem); line-height:1.04; margin:0 0 26px;
         letter-spacing:-.01em; text-wrap:balance;
@@ -90,17 +100,19 @@
 
       /* ---------- proof band ---------- */
       .proof{border-top:1px solid var(--hairline); border-bottom:1px solid var(--hairline);}
-      .proof-grid{display:grid; grid-template-columns:repeat(4,1fr);}
-      @media (max-width:860px){ .proof-grid{grid-template-columns:repeat(2,1fr);} }
+      .proof-grid{display:grid; grid-template-columns:repeat(4,minmax(0,1fr));}
+      @media (max-width:860px){ .proof-grid{grid-template-columns:repeat(2,minmax(0,1fr));} }
       .proof-item{padding:34px clamp(16px,2.5vw,34px); border-left:1px solid var(--hairline);}
       .proof-item:first-child{border-left:0;}
       @media (max-width:860px){ .proof-item:nth-child(3){border-left:0;} .proof-item:nth-child(n+3){border-top:1px solid var(--hairline);} }
+      @media (max-width:640px){ .proof-item{padding:24px 18px;} }
       .proof-item b{display:block; font-size:clamp(1.3rem,2.2vw,1.7rem); font-weight:400; margin-bottom:6px;}
       .proof-item span{font-size:.78rem; color:var(--stone); letter-spacing:.02em;}
 
       /* ---------- sections ---------- */
-      section{padding:clamp(60px,9vh,110px) 0;}
-      .sec-head{display:flex; align-items:baseline; justify-content:space-between; gap:20px; margin-bottom:clamp(30px,5vh,54px);}
+      section{padding-top:clamp(60px,9vh,110px); padding-bottom:clamp(60px,9vh,110px);}
+      @media (max-width:640px){ section{padding-top:48px; padding-bottom:48px;} }
+      .sec-head{display:flex; flex-wrap:wrap; align-items:baseline; justify-content:space-between; gap:10px 20px; margin-bottom:clamp(30px,5vh,54px);}
       h2{font-size:clamp(1.9rem,3.6vw,2.9rem); margin:0; line-height:1.1; text-wrap:balance;}
       .sec-head .count{color:var(--stone); font-size:.75rem; letter-spacing:.2em; text-transform:uppercase; white-space:nowrap;}
 
@@ -110,7 +122,7 @@
         padding:clamp(30px,5vh,50px) 0; border-top:1px solid var(--hairline);
       }
       .work-row:last-child{border-bottom:1px solid var(--hairline);}
-      @media (max-width:700px){ .work-row{grid-template-columns:1fr; gap:12px;} }
+      @media (max-width:700px){ .work-row{grid-template-columns:minmax(0,1fr); gap:12px;} }
       .years{
         font-size:.78rem; letter-spacing:.18em; text-transform:uppercase; color:var(--bronze);
         font-weight:600; padding-top:10px; font-variant-numeric:tabular-nums;
@@ -133,8 +145,8 @@
 
       /* featured BOPF */
       .featured{background:var(--card); border:1px solid var(--hairline); border-radius:4px; padding:clamp(26px,4vw,48px); margin-top:8px;}
-      .featured-grid{display:grid; grid-template-columns:repeat(2,1fr); gap:clamp(22px,3.5vw,44px);}
-      @media (max-width:760px){ .featured-grid{grid-template-columns:1fr;} }
+      .featured-grid{display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:clamp(22px,3.5vw,44px);}
+      @media (max-width:760px){ .featured-grid{grid-template-columns:minmax(0,1fr);} }
       .featured h4{
         font-size:.7rem; letter-spacing:.24em; text-transform:uppercase; color:var(--bronze);
         margin:0 0 10px; font-weight:700;
@@ -145,9 +157,10 @@
       .featured li{margin-bottom:7px;}
 
       /* campaign mini-grid */
-      .mini-grid{display:grid; grid-template-columns:repeat(2,1fr); gap:1px; background:var(--hairline); border:1px solid var(--hairline); margin-top:6px;}
-      @media (max-width:640px){ .mini-grid{grid-template-columns:1fr;} }
+      .mini-grid{display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:1px; background:var(--hairline); border:1px solid var(--hairline); margin-top:6px;}
+      @media (max-width:640px){ .mini-grid{grid-template-columns:minmax(0,1fr);} }
       .mini{background:var(--card); padding:22px 24px;}
+      @media (max-width:640px){ .mini{padding:18px 20px;} }
       .mini h4{margin:0 0 8px; font-size:1.05rem;}
       .mini p{font-size:.88rem; margin:0; color:var(--stone); max-width:none;}
 
@@ -157,18 +170,18 @@
         display:grid; grid-template-columns:minmax(180px,.42fr) minmax(0,1fr); gap:clamp(16px,4vw,60px);
         padding:26px 0; border-bottom:1px solid var(--hairline); align-items:baseline;
       }
-      @media (max-width:640px){ .cap{grid-template-columns:1fr; gap:6px;} }
+      @media (max-width:640px){ .cap{grid-template-columns:minmax(0,1fr); gap:6px; padding:22px 0;} }
       .cap h3{margin:0; font-size:1.25rem;}
       .cap p{margin:0; color:var(--stone); font-size:.95rem; max-width:66ch;}
 
       /* about */
       .about-grid{display:grid; grid-template-columns:minmax(0,.9fr) minmax(0,1.1fr); gap:clamp(26px,5vw,70px);}
-      @media (max-width:760px){ .about-grid{grid-template-columns:1fr;} }
+      @media (max-width:760px){ .about-grid{grid-template-columns:minmax(0,1fr);} }
       .about-grid .lede{font-size:clamp(1.25rem,2.2vw,1.6rem); line-height:1.4; margin:0;}
       .about-grid p{margin:0 0 18px; max-width:60ch;}
 
       /* contact */
-      footer{border-top:1px solid var(--hairline); padding:clamp(50px,8vh,90px) 0 60px;}
+      footer{border-top:1px solid var(--hairline); padding-top:clamp(50px,8vh,90px); padding-bottom:60px;}
       .contact-line{font-size:clamp(1.7rem,3.4vw,2.7rem); margin:0 0 30px; max-width:20em;}
       .contact-links{display:flex; flex-wrap:wrap; gap:14px;}
       .contact-links a{


### PR DESCRIPTION
Fixes the mobile issues on the v2 design:

- Layout viewport no longer stretches to 465px on phones (section-header label and nav were forcing min-content width); page now lays out at true device width
- Hero/section/footer padding shorthand was zeroing the horizontal gutter — portrait and headline no longer touch the screen edge
- All four nav links now shown on mobile via wrapping and smaller type (previously Capabilities was hidden)
- Grids hardened with minmax(0,1fr), overflow-x:clip safety, and a mobile spacing pass (24px gutters, tuned section/proof/card padding)

Verified at 390px and 1280px with emulated Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3KdQvQRVFwwvNyA8ahDfF

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3KdQvQRVFwwvNyA8ahDfF)_